### PR TITLE
chore(deps): add weekly dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "08:00"
+      timezone: "Australia/Perth"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "08:00"
+      timezone: "Australia/Perth"


### PR DESCRIPTION
## Summary

Adds Dependabot configuration to keep Go modules and GitHub Actions dependencies up to date on a predictable cadence. Updates are scheduled weekly for Friday at 08:00 in the Australia/Perth timezone (AWST).

## Changes

- Add `.github/dependabot.yml` with `gomod` updates from the repository root
- Add `.github/dependabot.yml` with `github-actions` updates from the repository root
- Configure both ecosystems to run weekly on Friday at 08:00 `Australia/Perth`
