### PR TITLE
chore(ci): set golangci-lint action to install-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          args: --timeout=5m
+          install-only: true
 
       - name: Install go-task
         uses: rsclarke/install-task@7c5a961f5d0c66abcdedc332e538ef042297b928 # v1.1.0


### PR DESCRIPTION
## Summary

This PR updates the CI workflow to install `golangci-lint` without executing it in the GitHub Action step. Linting still runs as part of `task ci`, so this avoids duplicate lint execution while preserving the existing checks.

## Changes

- Update the `golangci/golangci-lint-action` step in `.github/workflows/ci.yml` to use `install-only: true`
- Remove the direct action lint invocation configuration (`args: --timeout=5m`) because lint is run by `task ci`
