### PR TITLE
chore(lint): use revive default rule set

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,13 +30,7 @@ linters:
       asserts: true
       comparison: true
     revive:
-      rules:
-        - name: context-as-argument
-        - name: var-naming
-        - name: exported
-        - name: package-comments
-        - name: receiver-naming
-        - name: indent-error-flow
+      enable-default-rules: true
     nolintlint:
       require-explanation: true
       require-specific: true

--- a/storage.go
+++ b/storage.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/caddyserver/certmagic"
 	"github.com/google/uuid"
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // register pure-Go SQLite driver
 )
 
 var (


### PR DESCRIPTION
## Summary

Move the revive linter configuration toward defaults by replacing the explicit list of 6 rules with `enable-default-rules: true`, activating all 23 default rules. The single new finding (`blank-imports`) is triaged and addressed inline.

## Changes

- Replace explicit revive rule list with `enable-default-rules: true`, gaining 17 additional default rules
- Add justifying comment to the `modernc.org/sqlite` blank import to satisfy the `blank-imports` rule

Closes #17