### PR TITLE
chore(lint): expand golangci-lint with 24 additional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,28 +1,52 @@
 version: "2"
 linters:
   enable:
+    - asciicheck
+    - bidichk
     - bodyclose
+    - canonicalheader
     - contextcheck
+    - copyloopvar
     - durationcheck
     - errcheck
+    - errchkjson
+    - errname
     - errorlint
+    - exptostd
+    - fatcontext
+    - gocheckcompilerdirectives
+    - gocritic
     - godot
     - govet
     - ineffassign
+    - intrange
+    - mirror
     - misspell
+    - modernize
+    - nakedret
     - nilerr
+    - nilnesserr
     - nilnil
     - noctx
     - nolintlint
+    - nosprintfhostport
+    - perfsprint
     - predeclared
-    - rowserrcheck
+    - reassign
+    - recvcheck
     - revive
+    - rowserrcheck
     - sqlclosecheck
     - staticcheck
+    - thelper
     - unconvert
-    - unqueryvet
-    - gosec
     - unparam
+    - unqueryvet
+    - unused
+    - usestdlibvars
+    - usetesting
+    - wastedassign
+    - gosec
     - wrapcheck
   settings:
     errorlint:

--- a/storage_test.go
+++ b/storage_test.go
@@ -381,10 +381,10 @@ func TestConcurrentStoreLoad(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
 
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < iterations; j++ {
+			for range iterations {
 				key := "concurrent/key"
 				value := []byte("data")
 				if err := s.Store(ctx, key, value); err != nil {


### PR DESCRIPTION
## Summary

Expands the golangci-lint configuration with 24 additional linters covering correctness, modernisation, performance, and style — chosen for relevance to this codebase while avoiding opinionated or noisy checkers.

## Changes

- Enable 24 new linters: asciicheck, bidichk, canonicalheader, copyloopvar, errchkjson, errname, exptostd, fatcontext, gocheckcompilerdirectives, gocritic, intrange, mirror, modernize, nakedret, nilnesserr, nosprintfhostport, perfsprint, reassign, recvcheck, thelper, unused, usestdlibvars, usetesting, and wastedassign
- Explicitly list `unused` (previously only implicitly enabled as a default)
- Fix intrange findings in `storage_test.go` by converting counted `for` loops to `for range`