### PR TITLE
chore: harden GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "friday"
       time: "08:00"
       timezone: "Australia/Perth"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +17,5 @@ updates:
       day: "friday"
       time: "08:00"
       timezone: "Australia/Perth"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
   test:
+    name: Test
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: Run zizmor
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # Required to upload zizmor SARIF to GitHub code scanning.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -123,6 +123,16 @@ tasks:
     cmds:
       - golangci-lint run --fix
 
+  zizmor:
+    desc: Run zizmor
+    cmds:
+      - zizmor --strict-collection .
+
+  zizmor:fix:
+    desc: Run zizmor with safe automatic fixes
+    cmds:
+      - zizmor --fix=safe --strict-collection .
+
   test:
     desc: Run tests
     cmds:


### PR DESCRIPTION
Hardens the repository's GitHub Actions surface with least-privilege permissions, safer checkout behavior, Dependabot cooldowns, and ongoing zizmor auditing. This also adds Taskfile shortcuts so local zizmor audits and safe fixes can be run consistently.

- Reduce CI token exposure by setting workflow-level empty permissions, granting only read access for the test job, and disabling checkout credential persistence.
- Add Dependabot cooldowns for Go module and GitHub Actions updates.
- Address zizmor auditor findings by adding CI concurrency limits and an explicit test job name.
- Add a pinned zizmor audit workflow that uploads SARIF to GitHub code scanning.
- Add `task zizmor` and `task zizmor:fix` shortcuts.
