### PR TITLE
chore(actions): scope zizmor workflow triggers

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,8 +3,12 @@ name: Run zizmor
 on:
   pull_request:
     branches: [main]
+    paths:
+      - .github/**
   push:
     branches: [main]
+    paths:
+      - .github/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Scopes the zizmor workflow to changes under `.github/`, where this Go library's auditable GitHub configuration lives. This avoids running the Actions security audit for Go-only changes while continuing to check workflow and repository automation updates.

- Add `.github/**` path filters to the `pull_request` and `push` triggers.
- Preserve the existing `main` branch filters and workflow permissions.
